### PR TITLE
Update license in NDerivative to prevent etherscan-verify failure

### DIFF
--- a/contracts/NDerivative.sol
+++ b/contracts/NDerivative.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity 0.8.6;
 
 import "@openzeppelin/contracts/access/Ownable.sol";


### PR DESCRIPTION
etherscan-verify will fail with the current license as it is not
within the list of supported licenses (or is not properly labeled
with "UNLICENSED"). Changing to MIT to follow the other contracts
as part of n-pass