### PR TITLE
Pausable Contract

### DIFF
--- a/contracts/core/NPassCore.sol
+++ b/contracts/core/NPassCore.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.6;
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Pausable.sol";
 import "../interfaces/IN.sol";
 
 /**
@@ -12,7 +13,7 @@ import "../interfaces/IN.sol";
  * @notice This contract provides basic functionalities to allow minting using the NPass
  * @dev This contract should be used only for testing or testnet deployments
  */
-abstract contract NPassCore is ERC721Enumerable, ReentrancyGuard, Ownable {
+abstract contract NPassCore is ERC721Enumerable, ERC721Pausable, ReentrancyGuard, Ownable {
     uint256 public constant MAX_MULTI_MINT_AMOUNT = 32;
     uint256 public constant MAX_N_TOKEN_ID = 8888;
 
@@ -160,5 +161,48 @@ abstract contract NPassCore is ERC721Enumerable, ReentrancyGuard, Ownable {
      */
     function withdrawAll() external onlyOwner {
         payable(owner()).transfer(address(this).balance);
+    }
+
+    //
+    // PAUSE
+    //
+
+    /**
+     * @dev Pauses all token transfers.
+     *
+     * See {ERC721Pausable} and {Pausable-_pause}.
+     */
+    function pause() public virtual onlyOwner {
+        _pause();
+    }
+
+    /**
+     * @dev Unpauses all token transfers.
+     *
+     * See {ERC721Pausable} and {Pausable-_unpause}.
+     */
+    function unpause() public virtual onlyOwner {
+        _unpause();
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override(ERC721Enumerable, ERC721Pausable) {
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC721, ERC721Enumerable)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/core/NPassCore.sol
+++ b/contracts/core/NPassCore.sol
@@ -24,6 +24,8 @@ abstract contract NPassCore is ERC721Enumerable, ReentrancyGuard, Ownable {
     uint256 public immutable priceForNHoldersInWei;
     uint256 public immutable priceForOpenMintInWei;
 
+    event Mint(address to, uint256 tokenId);
+
     /**
      * @notice Construct an NPassCore instance
      * @param name Name of the token
@@ -82,6 +84,7 @@ abstract contract NPassCore is ERC721Enumerable, ReentrancyGuard, Ownable {
         }
         for (uint256 i = 0; i < maxTokensToMint; i++) {
             _safeMint(msg.sender, tokenIds[i]);
+            emit Mint(msg.sender, tokenIds[i]);
         }
     }
 
@@ -103,6 +106,7 @@ abstract contract NPassCore is ERC721Enumerable, ReentrancyGuard, Ownable {
             reserveMinted++;
         }
         _safeMint(msg.sender, tokenId);
+        emit Mint(msg.sender, tokenId);
     }
 
     /**
@@ -121,6 +125,7 @@ abstract contract NPassCore is ERC721Enumerable, ReentrancyGuard, Ownable {
         require(msg.value == priceForOpenMintInWei, "NPass:INVALID_PRICE");
 
         _safeMint(msg.sender, tokenId);
+        emit Mint(msg.sender, tokenId);
     }
 
     /**

--- a/test/unit/NPass.test.ts
+++ b/test/unit/NPass.test.ts
@@ -315,4 +315,23 @@ describe("NPass", function () {
     });
 
   });
+
+  describe("Pause", async function () {
+    it("Owner can pause and unpause", async () => {
+      await deployer.NDerivative.mint(9999);
+      expect(await contracts.NDerivative.ownerOf(9999)).to.be.equals(deployer.address);
+      // pause
+      await deployer.NDerivative.pause();
+      await expect(deployer.NDerivative.mint(9988)).to.be.revertedWith("ERC721Pausable: token transfer while paused");
+      // unpause
+      await deployer.NDerivative.unpause();
+      await deployer.NDerivative.mint(9988);
+      expect(await contracts.NDerivative.ownerOf(9988)).to.be.equals(deployer.address);
+    });
+
+    it("Users can't pause ", async () => {
+      await expect(users[0].NDerivative.pause()).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+  });
+
 });

--- a/test/unit/NPass.test.ts
+++ b/test/unit/NPass.test.ts
@@ -289,4 +289,30 @@ describe("NPass", function () {
       ).to.be.revertedWith("NPass:INVALID_PRICE");
     });
   });
+
+  describe('Events', async () => {
+    it("Mint should emit a Mint Event", async () => {
+      const tx = await deployer.NDerivative.mint(9999);
+      const receipt = await tx.wait();
+      const mintEvent = receipt.events?.filter(e => e.event == "Mint");
+      expect(mintEvent).to.be.length(1);
+      const args = mintEvent ? mintEvent[0].args : null;
+      expect(args?.tokenId.toString()).to.equal("9999");
+      expect(args?.to).to.equal(deployer.address);
+    });
+
+    it("Multiple Mint should emit a multiple Mint Events", async function () {
+      await deployer.N.claim(1);
+      await deployer.N.claim(2);
+      await deployer.N.claim(3);
+      expect(await contracts.N.ownerOf(1)).to.be.equals(deployer.address);
+      expect(await contracts.N.ownerOf(2)).to.be.equals(deployer.address);
+      expect(await contracts.N.ownerOf(3)).to.be.equals(deployer.address);
+      const tx = await deployer.NDerivative.multiMintWithN([1, 2, 3]);
+      const receipt = await tx.wait();
+      const mintEvent = receipt.events?.filter(e => e.event == "Mint");
+      expect(mintEvent).to.be.length(3);
+    });
+
+  });
 });


### PR DESCRIPTION
- Added functions to pause and unpause transfers (includes minting)
- code from OpenZeppelin examples: pause, unpause, _beforeTokenTransfer, supportsInterface